### PR TITLE
Feature/replay

### DIFF
--- a/bus/bus.go
+++ b/bus/bus.go
@@ -16,6 +16,9 @@ const exchangeName = "events.publish"
 //EventstoreQueue is a queue that will receive all events to be stored in influxdb
 const EventstoreQueue = "event.store.queue"
 
+//EventsReplayQueue is the queue that will receive events if solution is recording events
+const EventsReplayQueue = "event.replay.%s.queue"
+
 //EventPersistQueue is a queue that will receive all persist event
 const EventPersistQueue = "event.persist.queue"
 

--- a/flow/router.go
+++ b/flow/router.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ONSBR/Plataforma-EventManager/handlers/middlewares"
 	"github.com/ONSBR/Plataforma-EventManager/infra/factories"
 	"github.com/ONSBR/Plataforma-EventManager/processor"
+	"github.com/ONSBR/Plataforma-EventManager/sdk"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -30,11 +31,16 @@ func GetBasicEventRouter() *processor.Processor {
 			log.Error(err)
 			return err
 		}
-		//TODO
-		/*
-			Caso a aplicação esteja em modo gravação deve-se enviar o evento para ser gravado na fita no servico de replay
+		isRecording, err := sdk.IsRecording(c.Event.SystemID)
+		if err != nil {
+			log.Error(err)
+		}
+		if isRecording {
+			if err := sdk.RecordEvent(c.Event); err != nil {
+				log.Error(err)
+			}
 
-		*/
+		}
 		return c.Publish("store", c.Event)
 	})
 	return p

--- a/flow/router.go
+++ b/flow/router.go
@@ -30,6 +30,11 @@ func GetBasicEventRouter() *processor.Processor {
 			log.Error(err)
 			return err
 		}
+		//TODO
+		/*
+			Caso a aplicação esteja em modo gravação deve-se enviar o evento para ser gravado na fita no servico de replay
+
+		*/
 		return c.Publish("store", c.Event)
 	})
 	return p

--- a/handlers/handle_general_event.go
+++ b/handlers/handle_general_event.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ONSBR/Plataforma-EventManager/actions"
 	"github.com/ONSBR/Plataforma-EventManager/processor"
+	"github.com/ONSBR/Plataforma-EventManager/sdk"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -31,11 +32,23 @@ func handleExecutionGeneralEvent(c *processor.Context) error {
 		log.Error(err)
 		return err
 	} else {
+		isRecording, err := sdk.IsRecording(c.Event.SystemID)
+		if err != nil {
+			log.Error(err)
+		}
 		for _, event := range events {
-			if err := c.Publish("store.executor", event); err != nil {
-				log.Error(err)
-				return err
+			if isRecording {
+				if err := c.Publish(fmt.Sprintf("replay_%s", c.Event.SystemID), event); err != nil {
+					log.Error(err)
+					return err
+				}
+			} else {
+				if err := c.Publish("store.executor", event); err != nil {
+					log.Error(err)
+					return err
+				}
 			}
+
 		}
 	}
 	return nil

--- a/sdk/replay.go
+++ b/sdk/replay.go
@@ -3,6 +3,8 @@ package sdk
 import (
 	"fmt"
 
+	"github.com/ONSBR/Plataforma-EventManager/domain"
+
 	"github.com/ONSBR/Plataforma-Deployer/env"
 	"github.com/PMoneda/http"
 	log "github.com/sirupsen/logrus"
@@ -26,4 +28,21 @@ func IsRecording(systemID string) (bool, error) {
 		return false, nil
 	}
 	return true, nil
+}
+
+//RecordEvent records an event synchronously at replay service
+func RecordEvent(event *domain.Event) error {
+	scheme := env.Get("REPLAY_SCHEME", "http")
+	host := env.Get("REPLAY_HOST", "localhost")
+	port := env.Get("REPLAY_PORT", "6081")
+	url := fmt.Sprintf("%s://%s:%s/v1/tape/%s/record", scheme, host, port, event.SystemID)
+	resp, err := http.Post(url, event)
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+	if resp.Status != 200 && resp.Status != 404 {
+		return fmt.Errorf("Error on recording event with systemID=%s data=%s", event.SystemID, string(resp.Body))
+	}
+	return nil
 }

--- a/sdk/replay.go
+++ b/sdk/replay.go
@@ -1,0 +1,29 @@
+package sdk
+
+import (
+	"fmt"
+
+	"github.com/ONSBR/Plataforma-Deployer/env"
+	"github.com/PMoneda/http"
+	log "github.com/sirupsen/logrus"
+)
+
+//IsRecording checks if current system is in recording state
+func IsRecording(systemID string) (bool, error) {
+	scheme := env.Get("REPLAY_SCHEME", "http")
+	host := env.Get("REPLAY_HOST", "localhost")
+	port := env.Get("REPLAY_PORT", "6081")
+	url := fmt.Sprintf("%s://%s:%s/v1/tape/%s/recording", scheme, host, port, systemID)
+	resp, err := http.Get(url)
+	if err != nil {
+		log.Error(err)
+		return false, nil
+	}
+	if resp.Status != 200 && resp.Status != 404 {
+		return false, fmt.Errorf("Error on checking is Recording with systemID=%s data=%s", systemID, string(resp.Body))
+	}
+	if resp.Status == 404 {
+		return false, nil
+	}
+	return true, nil
+}


### PR DESCRIPTION
### O que?
Ajustes realizados para que o serviço de replay funcione adequadamente:

### Como?
Quando a aplicação está em modo de gravação o event manager envia o evento recebido para a fila de gravação e o serviço de replay após gravar o evento o reenvia para a fila de execução para seguir o fluxo normal de plataforma.

Para as presentations apps que fazem transações sincronas também foi adicionado suporte para que os eventos sincronos também sejam gravados.

async Evento -> Flow(*) -> FilaGravacao -> Serviço Gravação -> Fila Execução -> Executor 


sync Evento -> BasicFlow(*) -> Api Gravação -> Retorno Usuário

### Porque?
As alterações nesse serviço foram necessárias pois o event manager é o serviço responsável pelo recebimento de todos os eventos da plataforma.
